### PR TITLE
Add canImport around Cocoa uses (in AttributedString)

### DIFF
--- a/Sources/MarkdownKit/AttributedString/AttributedStringGenerator.swift
+++ b/Sources/MarkdownKit/AttributedString/AttributedStringGenerator.swift
@@ -18,6 +18,7 @@
 //  limitations under the License.
 //
 
+#if canImport(Cocoa)
 import Cocoa
 
 ///
@@ -359,3 +360,4 @@ open class AttributedStringGenerator {
     return 2
   }
 }
+#endif

--- a/Sources/MarkdownKit/AttributedString/NSColor.swift
+++ b/Sources/MarkdownKit/AttributedString/NSColor.swift
@@ -18,6 +18,7 @@
 //  limitations under the License.
 //
 
+#if canImport(Cocoa)
 import Foundation
 import Cocoa
 
@@ -33,3 +34,4 @@ extension NSColor {
     return String(format: "#%02X%02X%02X", red, green, blue)
   }
 }
+#endif


### PR DESCRIPTION
This allows use on iOS as well as macOS