### PR TITLE
cleanup minor typo in document and blockquote description strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ document(heading(1, text("Header")),
          heading(2, text("Sub-header")),
          paragraph(text("And this is a "),
                    strong(text("paragraph")),
-                   text("."))))
+                   text(".")))
 ```
 
 [`Block`](https://github.com/objecthub/swift-markdownkit/blob/master/Sources/MarkdownKit/Block.swift)

--- a/Sources/MarkdownKit/Block.swift
+++ b/Sources/MarkdownKit/Block.swift
@@ -45,9 +45,9 @@ public enum Block: Equatable, CustomStringConvertible, CustomDebugStringConverti
   public var description: String {
     switch self {
       case .document(let blocks):
-        return "document(\(Block.string(from: blocks))))"
+        return "document(\(Block.string(from: blocks)))"
       case .blockquote(let blocks):
-        return "blockquote(\(Block.string(from: blocks))))"
+        return "blockquote(\(Block.string(from: blocks)))"
       case .list(let start, let tight, let blocks):
         if let start = start {
           return "list(\(start), \(tight ? "tight" : "loose"), \(Block.string(from: blocks)))"


### PR DESCRIPTION
before: `document( ))`
after: `document( )`